### PR TITLE
Install cctools into Darling CLT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(cctools)
 set(CCTOOLS_VERSION 895)
-set(CCTOOLS_INSTALL_DEST "libexec/darling/usr/libexec/DeveloperTools")
+set(CCTOOLS_INSTALL_DEST "libexec/darling/Library/Developer/DarlingCLT/usr/bin/")
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_subdirectory(libstuff)


### PR DESCRIPTION
This allow Darling to use tools like ```otool``` without specifying the full path.